### PR TITLE
Add notepadqq

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 ## for many languages
 
 - Notepad++ (Windows only)
+- Notepadqq (GNU/Linux & \*BSD only)
 - Atom
 - GVim (Vim with GUI)
 - Emacs (editor/IDE)


### PR DESCRIPTION
[Notepadqq](https://notepadqq.com) is likely a replacement for Notepad++ but mainly for GNU/Linux. Source build can be done under various BSD operating system too.